### PR TITLE
update color brightness calculation

### DIFF
--- a/application/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsModule.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsModule.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.gtfs.graphbuilder;
 
+import static org.opentripplanner.utils.color.ColorUtils.computeBrightness;
+
 import java.awt.Color;
 import java.io.IOException;
 import java.io.Serializable;
@@ -52,6 +54,7 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.standalone.config.BuildConfig;
 import org.opentripplanner.transit.model.framework.FeedScopedId;
 import org.opentripplanner.transit.service.TimetableRepository;
+import org.opentripplanner.utils.color.Brightness;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -415,8 +418,7 @@ public class GtfsModule implements GraphBuilderModule {
    * If a route doesn't have color or already has routeColor and routeTextColor nothing is done.
    * <p>
    * textColor can be black or white. White for dark colors and black for light colors of
-   * routeColor. If color is light or dark is calculated based on luminance formula: sqrt(
-   * 0.299*Red^2 + 0.587*Green^2 + 0.114*Blue^2 )
+   * routeColor.
    */
   private void generateRouteColor(Route route) {
     String routeColor = route.getColor();
@@ -431,16 +433,7 @@ public class GtfsModule implements GraphBuilderModule {
     }
 
     Color routeColorColor = Color.decode("#" + routeColor);
-    //gets float of RED, GREEN, BLUE in range 0...1
-    float[] colorComponents = routeColorColor.getRGBColorComponents(null);
-    //Calculates luminance based on https://stackoverflow.com/questions/596216/formula-to-determine-brightness-of-rgb-color
-    double newRed = 0.299 * Math.pow(colorComponents[0], 2.0);
-    double newGreen = 0.587 * Math.pow(colorComponents[1], 2.0);
-    double newBlue = 0.114 * Math.pow(colorComponents[2], 2.0);
-    double luminance = Math.sqrt(newRed + newGreen + newBlue);
-
-    //For brighter colors use black text color and reverse for darker
-    if (luminance > 0.5) {
+    if (computeBrightness(routeColorColor) == Brightness.LIGHT) {
       textColor = "000000";
     } else {
       textColor = "FFFFFF";

--- a/utils/src/main/java/org/opentripplanner/utils/color/Brightness.java
+++ b/utils/src/main/java/org/opentripplanner/utils/color/Brightness.java
@@ -1,0 +1,6 @@
+package org.opentripplanner.utils.color;
+
+public enum Brightness {
+  DARK,
+  LIGHT,
+}

--- a/utils/src/main/java/org/opentripplanner/utils/color/ColorUtils.java
+++ b/utils/src/main/java/org/opentripplanner/utils/color/ColorUtils.java
@@ -1,0 +1,44 @@
+package org.opentripplanner.utils.color;
+
+import java.awt.Color;
+
+public final class ColorUtils {
+
+  private ColorUtils() {}
+
+  /**
+   * Calculates luminance according to
+   * <a href="https://www.w3.org/TR/WCAG21/#dfn-relative-luminance">W3C Recommendation</a>
+   */
+  public static double computeLuminance(Color color) {
+    //gets float of RED, GREEN, BLUE in range 0...1
+    float[] colorComponents = color.getRGBColorComponents(null);
+    //Calculates luminance based on https://stackoverflow.com/questions/596216/formula-to-determine-brightness-of-rgb-color
+    double r = linearizeColorComponent(colorComponents[0]);
+    double g = linearizeColorComponent(colorComponents[1]);
+    double b = linearizeColorComponent(colorComponents[2]);
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  }
+
+  private static double linearizeColorComponent(double srgb) {
+    return srgb <= 0.04045 ? srgb / 12.92 : Math.pow((srgb + 0.055) / 1.055, 2.4);
+  }
+
+  /**
+   * Determine if a color is light or dark
+   * <p>
+   * A light color is a color where the contrast ratio with black is larger than with white.
+   * <p>
+   * The contrast ratio is defined per Web Content Accessibility Guidelines (WCAG) 2.1.
+   */
+  public static Brightness computeBrightness(Color color) {
+    // The contrast ratio between two colors is defined as (L1 + 0.05) / (L2 + 0.05)
+    // where L1 is the lighter of the two colors.
+    //
+    // Therefore, the contrast ratio with black is (L + 0.05) / 0.05 and the contrast ratio with
+    // white is 1.05 / (L + 0.05)
+    //
+    // Solving (L + 0.05) / 0.05 > 1.05 / (L + 0.05) gets L > 0.179
+    return computeLuminance(color) > 0.179 ? Brightness.LIGHT : Brightness.DARK;
+  }
+}

--- a/utils/src/test/java/org/opentripplanner/utils/color/ColorUtilsTest.java
+++ b/utils/src/test/java/org/opentripplanner/utils/color/ColorUtilsTest.java
@@ -1,0 +1,31 @@
+package org.opentripplanner.utils.color;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.opentripplanner.utils.color.ColorUtils.computeBrightness;
+
+import java.awt.Color;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.FieldSource;
+
+public class ColorUtilsTest {
+
+  static final Arguments[] brightnessExpectations = {
+    arguments(Color.black, Brightness.DARK),
+    arguments(Color.green, Brightness.LIGHT),
+    arguments(Color.blue, Brightness.DARK),
+    arguments(Color.red, Brightness.LIGHT),
+    arguments(Color.yellow, Brightness.LIGHT),
+    arguments(Color.white, Brightness.LIGHT),
+    arguments(Color.pink, Brightness.LIGHT),
+    arguments(Color.orange, Brightness.LIGHT),
+    arguments(Color.cyan, Brightness.LIGHT),
+  };
+
+  @ParameterizedTest
+  @FieldSource("brightnessExpectations")
+  void testBrightness(Color color, Brightness brightness) {
+    assertEquals(computeBrightness(color), brightness);
+  }
+}


### PR DESCRIPTION
## PR Instructions

### Summary

This is a rework of #5490 . It uses the WCAG recommendation to decide if the text color should be black (on a light background) or white (on a dark background).

The color calculation is refactored out into a separate util module such that it is testable, and is changed to use the official sRGB color space formula.

The luminance threshold is 0.179 according to the WCAG formula (where the previous code used 0.5). It has an effect of considering red (255, 0, 0) a light color that black text (instead of white) should be placed on red background, as black has a greater contrast with red than white per accessibility guidelines. This will need some discussion. 

### Issue

None

### Unit tests

Added for color calculation.

### Documentation

Javadoc

